### PR TITLE
Version constrain wide-word

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ description: See the file ./README.md, which is included in the package and also
 dependencies:
   - base >= 4.14.1.0 && < 5
   - bytestring >= 0.10.12.0
-  - wide-word >= 0.1.1.2
+  - wide-word >= 0.1.1.2 && <= 0.1.3.0
   - data-default >= 0.7.1.1
   - time >= 1.9.3
   - deepseq >= 1.4.4.0

--- a/snowchecked.cabal
+++ b/snowchecked.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -51,7 +51,7 @@ library
     , text >=1.2.4.1
     , text-conversions >=0.3.1
     , time >=1.9.3
-    , wide-word >=0.1.1.2
+    , wide-word >=0.1.1.2 && <=0.1.3.0
   default-language: Haskell2010
 
 test-suite test-suite
@@ -79,5 +79,5 @@ test-suite test-suite
     , text-conversions >=0.3.1
     , time >=1.9.3
     , unliftio
-    , wide-word >=0.1.1.2
+    , wide-word >=0.1.1.2 && <=0.1.3.0
   default-language: Haskell2010


### PR DESCRIPTION
Tests fail with newer versions of the package `wide-word`. This PR pins the package version to tested versions that pass the tests.

Version of `wide-word` of `0.1.4.0` and later will cause the tests to fail. Below is a snippet of one such failure.

```
       ┏━━ test/Integer.hs ━━━
    14 ┃ prop_flakeToIntegerToFlake :: Property
    15 ┃ prop_flakeToIntegerToFlake = property $ do
    16 ┃     cfg <- forAll genConfig
       ┃     │ SnowcheckedConfig
       ┃     │   { confTimeBits = 4
       ┃     │   , confCountBits = 0
       ┃     │   , confNodeBits = 128
       ┃     │   , confCheckBits = 0
       ┃     │   }
    17 ┃     flake <- forAllFlake' cfg
    18 ┃     let value = fromFlake @Integer flake
    19 ┃     annotateShow value
       ┃     │ 2041694201525630780806014779459328039765
    20 ┃     let result = parseFlake cfg value 
    21 ┃     result === Just flake
       ┃     ^^^^^^^^^^^^^^^^^^^^^
       ┃     │ ━━━ Failed (- lhs) (+ rhs) ━━━
       ┃     │   Just
       ┃     │     Flake {
       ┃     │         flakeTime =
       ┃     │           6
       ┃     │       , flakeCount =
       ┃     │           0
       ┃     │       , flakeNodeId =
       ┃     │ -         25767134868718771029
       ┃     │ +         6277101735386680764176071790128604879591497186764521495381
       ┃     │       , flakeConfig =
       ┃     │           SnowcheckedConfig
       ┃     │             { confTimeBits = 4
       ┃     │             , confCountBits = 0
       ┃     │             , confNodeBits = 128
       ┃     │             , confCheckBits = 0
       ┃     │             }
       ┃     │       }
```